### PR TITLE
support-datetime64-parameterless-constructor

### DIFF
--- a/tests/simple/main.cpp
+++ b/tests/simple/main.cpp
@@ -144,12 +144,12 @@ inline void testDateTimeType(Client& client) {
     /// Delete table.
     client.Execute("DROP STREAM IF EXISTS test_datetime");
     /// Create a table.
-    client.Execute("CREATE STREAM IF NOT EXISTS test_datetime (d date, d32 date32, dt32 datetime, dt64 datetime64(3))");
+    client.Execute("CREATE STREAM IF NOT EXISTS test_datetime (d date, d32 date32, dt32 datetime, dt64 datetime64)");
     
     auto d = std::make_shared<ColumnDate>();
     auto d32 = std::make_shared<ColumnDate32>();
     auto dt32 = std::make_shared<ColumnDateTime>();
-    auto dt64 = std::make_shared<ColumnDateTime64>(3);
+    auto dt64 = std::make_shared<ColumnDateTime64>();
 
     d->Append(std::time(nullptr));
     d32->Append(std::time(nullptr));
@@ -864,9 +864,9 @@ inline void ShowTables(Client& client) {
 static void RunTests(Client& client) {
     // testIntType(client); //1
     // testDecimalType(client); //1
-    testArrayType(client); //
+    // testArrayType(client); //
     // CancelableExample(client);
-    // testDateTimeType(client); //1
+    testDateTimeType(client); //1
     // testFloatType(client); //1
     // CancelableExample(client);
     // testEnumType(client); //2

--- a/timeplus/columns/date.cpp
+++ b/timeplus/columns/date.cpp
@@ -270,6 +270,10 @@ ItemView ColumnDateTime::GetItem(size_t index) const {
     return ItemView(Type::DateTime, data_->GetItem(index));
 }
 
+ColumnDateTime64::ColumnDateTime64()
+    : ColumnDateTime64(Type::CreateDateTime64(3ul), std::make_shared<ColumnDecimal>(18ul, 3ul))
+{}
+
 ColumnDateTime64::ColumnDateTime64(size_t precision)
     : ColumnDateTime64(Type::CreateDateTime64(precision), std::make_shared<ColumnDecimal>(18ul, precision))
 {}

--- a/timeplus/columns/date.h
+++ b/timeplus/columns/date.h
@@ -188,6 +188,7 @@ class ColumnDateTime64 : public Column {
 public:
     using ValueType = Int64;
 
+    ColumnDateTime64();
     explicit ColumnDateTime64(size_t precision);
     ColumnDateTime64(size_t precision, std::string timezone);
 


### PR DESCRIPTION
support for #7 